### PR TITLE
Provide org-babel-get-header as fallback for org-babel--get-vars

### DIFF
--- a/ob-prolog.el
+++ b/ob-prolog.el
@@ -83,7 +83,9 @@
 
 (defun org-babel-variable-assignments:prolog (params)
   (let ((strs (mapcar #'org-babel-prolog--variable-assignment
-		      (org-babel--get-vars params))))
+                      (if (fboundp 'org-babel--get-vars)
+                          (org-babel--get-vars params)
+                        (org-babel-get-header params :var)))))
     (when strs
       (list (concat ":- " (mapconcat #'identity strs ", ") ".\n")))))
 


### PR DESCRIPTION
Closes #13.  Discussion of the problem and proposed fix can be found at https://github.com/pope/ob-go/issues/10.